### PR TITLE
Fix for string trim function

### DIFF
--- a/ejc-format.el
+++ b/ejc-format.el
@@ -20,6 +20,7 @@
 
 (require 'cua-base)
 (require 'ejc-lib)
+(require 'subr-x)
 
 (defvar ejc-sql-separator "/"
   "The char with purpose to separate the SQL statement both other.")
@@ -144,7 +145,7 @@ buffer."
       max-length)))
 
 (defun ejc-is-separator-string (pos)
-  (equal (trim-string (buffer-substring
+  (equal (string-trim (buffer-substring
                        pos
                        (save-excursion
                          (end-of-line)

--- a/ejc-sql.el
+++ b/ejc-sql.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/clojure-emacs/clomacs
 ;; Keywords: sql, jdbc
 ;; Version: 0.0.1
-;; Package-Requires: ((clomacs "0.0.2")(dash "2.12.1")(auto-complete "1.5.1"))
+;; Package-Requires: ((emacs "24.4")(clomacs "0.0.2")(dash "2.12.1")(auto-complete "1.5.1"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
- Correct function name `trim-string` -> `string-trim`
- Load subr-x.el for using it
- Specify minimum Emacs version because subr-x.el was introduced at Emacs 24.4.