### PR TITLE
Use `concat` instead of `str` in elisp.

### DIFF
--- a/ejc-interaction.el
+++ b/ejc-interaction.el
@@ -158,8 +158,8 @@ Prepare SQL string, evaluate SQL script and write them to log file"
                set-rows-limit
                :lib-name "ejc-sql"
                :namespace ejc-sql.output
-               :doc (str "Set limit for number of records to output. "
-                         "When nil no limit."))
+               :doc (concat "Set limit for number of records to output. "
+                            "When nil no limit."))
 
 (clomacs-defun ejc-get-stucture
                get-stucture


### PR DESCRIPTION
Hi @kostafey 

Thanks for a great project.

I got the errors when trying to run `ejc-set-rows-limit` function.
I did a quick look and think this might be the fix and it did work after this change.