### PR TITLE
put ejc-sql snippets dir behind user custom dir

### DIFF
--- a/ejc-autocomplete.el
+++ b/ejc-autocomplete.el
@@ -188,10 +188,10 @@ something#"
 
 (when (require 'yasnippet nil 'noerror)
   (setq yas-snippet-dirs
-        (cons (expand-file-name "snippets"
-                                (file-name-directory
-                                 (locate-library "ejc-sql")))
-              yas-snippet-dirs))
+        (nconc yas-snippet-dirs
+               (list (expand-file-name "snippets"
+                                       (file-name-directory
+                                        (locate-library "ejc-sql"))))))
   (defun ejc-yas-downcase-key (args)
     (if ejc-sql-mode
         (cl-callf downcase (nth 1 args)))


### PR DESCRIPTION
When user create new snippet, then want to save, yasnippet always use
first dir in yas-snippet-dirs list. So all package snippets dirs should
behind default dir.