### PR TITLE
Use cl-case macro instead of case

### DIFF
--- a/ejc-sql.el
+++ b/ejc-sql.el
@@ -605,7 +605,7 @@ any SQL buffer to connect to exact database, as always. "
     sql))
 
 (defun ejc-add-outside-borders-p ()
-  (case ejc-result-table-impl
+  (cl-case ejc-result-table-impl
     (orgtbl-mode     t)
     (ejc-result-mode nil)))
 


### PR DESCRIPTION
Without this change I see the following error when I execute <kbd>C-c C-c</kbd> inside of an Org mode embeded sql block.

ejc-add-outside-borders-p: Wrong number of arguments: #[nil "Æ ÇÈÉÊËÌ!!ÈÇ!#ÍÎÏ!" [truncate-lines major-mode mode-name ejc-result-table-impl view-read-only font-lock-defaults kill-all-local-variables t ejc-result-mode "SQL-Result" ...] 6 nil nil], 1

```
Debugger entered--Lisp error: (wrong-number-of-arguments #f(compiled-function () (interactive nil) #<bytecode 0x1cdc688f3bb88055>) 1)
  ejc-result-mode(nil)
  ejc-add-outside-borders-p()
  ejc-eval-sql-and-log(((:classpath . "/home/joe/.m2/repository/postgresql/postgresql/9.3...") (:password . "exchange_development") (:user . "exchange_service") (:host . "localhost") (:dbname . "openmarkets_development") (:dbtype . "postgresql")) "select id FROM demands limit 1\n" :rows-limit nil :column-width-limit nil :start-time (24130 47140 135143 656000) :sync t :display-result nil)
  ejc-eval-user-sql("select id FROM demands limit 1\n" :sync t :display-result nil)
  ejc-eval-user-sql-at-point(:beg 23122 :end 23153 :sync t :display-result nil)
  ejc-eval-org-snippet(#f(compiled-function (body params) "Execute a block of Sql code with Babel.\nThis function is called by `org-babel-execute-src-block'." #<bytecode -0x1c0988191475ebac>) "select id FROM demands limit 1" ((:colname-names) (:rowname-names) (:result-params "replace") (:result-type . value) (:results . "replace") (:exports . "code") (:session . "none") (:cache . "no") (:noweb . "no") (:hlines . "no") (:tangle . "no")))
  apply(ejc-eval-org-snippet #f(compiled-function (body params) "Execute a block of Sql code with Babel.\nThis function is called by `org-babel-execute-src-block'." #<bytecode -0x1c0988191475ebac>) ("select id FROM demands limit 1" ((:colname-names) (:rowname-names) (:result-params "replace") (:result-type . value) (:results . "replace") (:exports . "code") (:session . "none") (:cache . "no") (:noweb . "no") (:hlines . "no") (:tangle . "no"))))
  org-babel-execute:sql("select id FROM demands limit 1" ((:colname-names) (:rowname-names) (:result-params "replace") (:result-type . value) (:results . "replace") (:exports . "code") (:session . "none") (:cache . "no") (:noweb . "no") (:hlines . "no") (:tangle . "no")))
  org-babel-execute-src-block(nil ("sql" "select id FROM demands limit 1" ((:colname-names) (:rowname-names) (:result-params "replace") (:result-type . value) (:results . "replace") (:exports . "code") (:tangle . "no") (:hlines . "no") (:noweb . "no") (:cache . "no") (:session . "none")) "" nil 23106 "(ref:%s)"))
  org-ctrl-c-ctrl-c(nil)
  funcall-interactively(org-ctrl-c-ctrl-c nil)
  call-interactively(org-ctrl-c-ctrl-c nil nil)
  command-execute(org-ctrl-c-ctrl-c)
```