### PR TITLE
support Emacs 28 eldoc new introduced hook variable

### DIFF
--- a/ejc-eldoc.el
+++ b/ejc-eldoc.el
@@ -130,7 +130,9 @@
 (defun ejc-eldoc-setup ()
   "Set up eldoc function and enable eldoc-mode."
   (interactive)
-  (setq-local eldoc-documentation-function #'ejc-eldoc-function)
+  (if (boundp 'eldoc-documentation-functions)
+      (add-hook 'eldoc-documentation-functions #'ejc-eldoc-function nil t)
+    (setq-local eldoc-documentation-function #'ejc-eldoc-function))
   (eldoc-mode +1))
 
 (provide 'ejc-eldoc)


### PR DESCRIPTION
I re-compiled it from master branch is Emacs v28. In this version, set
`eldoc-documentation-function` does not work. `eldoc-mode` report does not have
support for this mode. Setting `eldoc-documentation-functions` fixed this issue.