### PR TITLE
Update ejc-result-buffer.el

### DIFF
--- a/ejc-result-buffer.el
+++ b/ejc-result-buffer.el
@@ -148,7 +148,7 @@ or error messages."
       (beginning-of-buffer)
       (let* ((window (or (get-buffer-window output-buffer t)
                          (progn
-                           (display-buffer output-buffer)
+                           (display-buffer output-buffer '(display-buffer-at-bottom . ()))
                            (get-buffer-window output-buffer t))))
              (frame (window-frame window)))
         (if (not (eq frame (selected-frame)))

--- a/ejc-result-buffer.el
+++ b/ejc-result-buffer.el
@@ -43,6 +43,12 @@
   :group 'ejc-sql
   :type 'integer)
 
+(defcustom ejc-show-result-bottom t
+  "Show result output buffer in the bottom window. bottom by default, 
+     set to nil to show it in the right"
+  :group 'ejc-sql
+  :type 'boolean)
+
 (defvar ejc-ring-position 0
   "Current SQL evaluation result position in ring.")
 
@@ -148,7 +154,9 @@ or error messages."
       (beginning-of-buffer)
       (let* ((window (or (get-buffer-window output-buffer t)
                          (progn
-                           (display-buffer output-buffer '(display-buffer-at-bottom . ()))
+                           (if ejc-show-result-bottom
+                               (display-buffer output-buffer '(display-buffer-at-bottom . ()))
+                             (display-buffer output-buffer))
                            (get-buffer-window output-buffer t))))
              (frame (window-frame window)))
         (if (not (eq frame (selected-frame)))
@@ -182,7 +190,9 @@ or error messages."
       (insert-file-contents file-path)
       (ejc-output-mode-specific-customization)
       (beginning-of-buffer)
-      (display-buffer output-buffer)
+      (if ejc-show-result-bottom
+          (display-buffer output-buffer '(display-buffer-at-bottom . ()))
+        (display-buffer output-buffer))
       (message file-path))))
 
 ;;;###autoload


### PR DESCRIPTION
display result buffer in the bottom instead of right. I found that display the result buffer in the bottom will have a wide window, it helps especially for tables with many columns