### PR TITLE
Update ejc-sql.el

### DIFF
--- a/ejc-sql.el
+++ b/ejc-sql.el
@@ -861,7 +861,6 @@ Buffer can be saved to file with `ejc-temp-editor-file' path."
         (find-file tmp-file-path)
         (rename-buffer tmp-buffer-name)
         (sql-mode)
-        (auto-fill-mode t)
         (ejc-add-connection)
         (get-buffer tmp-buffer-name)))))
 


### PR DESCRIPTION
do not enable auto-fill-mode by default for `ejc-get-temp-editor-buffer`, I think enabling auto-fill-mode for sql doesn't make a not sense, so I suggest that don't enable it by default, thanks.