### PR TITLE
ejc-eval-org-snippet should expand noweb references

### DIFF
--- a/ejc-sql.el
+++ b/ejc-sql.el
@@ -397,12 +397,12 @@ If the current mode is `sql-mode' prepare buffer to operate as `ejc-sql-mode'."
                  (concat "ejc-sql is enabled, ignore source block connection"
                          " header arguments and use ejc-sql to execute it? ")))))
       (funcall orig-fun body params)
-    (cl-multiple-value-bind (beg end) (save-mark-and-excursion
-                                        (org-babel-mark-block)
-                                        (list (point) (mark)))
-      (ejc-eval-user-sql-at-point
-       :beg beg
-       :end end
+    (let* ((info (org-babel-get-src-block-info 'no-eval))
+           (expanded-body (if (org-babel-noweb-p (nth 2 info) :eval)
+                              (org-babel-expand-noweb-references info)
+                            (nth 1 info))))
+      (ejc-eval-user-sql
+       expanded-body
        :sync ejc-org-mode-show-results
        :display-result (not ejc-org-mode-show-results))
       (if ejc-org-mode-show-results


### PR DESCRIPTION
Currently evaluating org babel cells doesn't support expanding of noweb references:
```
#+name: tstest
#+begin_src sql :exports none
'2023-08-17 05:00:00'  
#+end_src

#+begin_src sql :exports none :noweb yes
  select <<tstest>>::DateTime
#+end_src
```

Based on `org-babel--expand-body` function in `ob-core.el`, I've made adjustment to `ejc-eval-org-snippet`