### PR TITLE
Convert BLOBs to strings

### DIFF
--- a/src/ejc_sql/connect.clj
+++ b/src/ejc_sql/connect.clj
@@ -22,7 +22,7 @@
             [clojure.string :as s]
             [clomacs :refer [clomacs-defn]]
             [ejc-sql.output :as o]
-            [ejc-sql.lib :refer [select? ddl? clob-to-string-row *max-column-width*]]
+            [ejc-sql.lib :refer [select? ddl? lob-to-string-row *max-column-width*]]
             [ejc-sql.cache :refer [invalidate-cache]])
   (:import [java.sql SQLException]))
 
@@ -188,7 +188,7 @@ SELECT * FROM urls WHERE path like '%http://localhost%'"
                                  (let [single-record?
                                        (not (next (next rs)))]
                                    (mapv
-                                    #(clob-to-string-row
+                                    #(lob-to-string-row
                                       % single-record?)
                                     rs)))})))
                   ;; DML or DDL

--- a/src/ejc_sql/lib.clj
+++ b/src/ejc_sql/lib.clj
@@ -78,13 +78,14 @@
            (str (subs result 0 (- *max-column-width* 3)) "...")
            result))))))
 
-(defn clob-to-string-row
-  "Check all data in row if it's a CLOB and convert CLOB to string."
+(defn lob-to-string-row
+  "Check all data in row if it's a LOB and convert CLOB/BLOB to string."
   [row single-record?]
   (mapv (fn [field]
-          (if (is-clob? field)
-            (clob-to-string field single-record?)
-            field))
+          (cond
+            (is-clob? field) (clob-to-string field single-record?)
+            (bytes? field) (String. field)
+            :else field))
         row))
 
 (defn clean-sql [sql]


### PR DESCRIPTION
Before, BLOBs would display an object reference since they are pulled as byte arrays. I noticed this in MariaDB specifically.

To test, run the following using ejc-sql, the blob column will appear like `[B@73dbe1ae` in master, with this PR you will see the actual value:
```sql
CREATE DATABASE test_db;
USE test_db;

CREATE TABLE storage_test (
    id INT AUTO_INCREMENT PRIMARY KEY,
    title VARCHAR(255) NOT NULL,
    text_content TEXT,
    blob_content BLOB
);

INSERT INTO storage_test (title, text_content, blob_content)
VALUES (
    'lorem ipsum dolor sit amet.',
    'lorem ipsum dolor sit amet. lorem ipsum dolor sit amet.',
    'lorem ipsum dolor sit amet. lorem ipsum dolor sit amet. lorem ipsum dolor sit amet.'
);
select * from test_db.storage_test;
```
